### PR TITLE
Add ||| block string syntax to grammar.

### DIFF
--- a/grammars/jsonnet.cson
+++ b/grammars/jsonnet.cson
@@ -75,6 +75,12 @@
   },
 
   {
+    'name': 'string.unquoted.block.jsonnet'
+    'begin': '\\|\\|\\|'
+    'end': '\\|\\|\\|'
+  },
+
+  {
     'name': 'comment.block.jsonnet'
     'begin': '/\\*'
     'end': '\\*/'


### PR DESCRIPTION
Screenshot:

<img width="607" alt="screen shot 2015-09-24 at 7 25 51 pm" src="https://cloud.githubusercontent.com/assets/5283042/10091583/17a1718a-62f2-11e5-8c9d-67d2435cc0a0.png">
