### PR TITLE
Add libsonnet to list of filetypes

### DIFF
--- a/grammars/jsonnet.cson
+++ b/grammars/jsonnet.cson
@@ -1,6 +1,6 @@
 'scopeName': 'source.jsonnet'
 'name': 'Jsonnet'
-'fileTypes': ['jsonnet']
+'fileTypes': ['jsonnet', 'libsonnet']
 'patterns': [
   {
     'name': 'constant.numeric.jsonnet'


### PR DESCRIPTION
Per recent reformatting changes, .libsonnet should now be recognized as a jsonnet
file type (e.g. https://github.com/google/jsonnet/commit/08f9af631927defb70c372e7aac821ff84772657).