### PR TITLE
fix: correctly highlight text verbatim

### DIFF
--- a/grammars/jsonnet.cson
+++ b/grammars/jsonnet.cson
@@ -142,19 +142,15 @@
   },
 
   {
-    'contentName': 'string.block.jsonnet'
-    'begin': '^(\\s*)(.*)(\\|\\|\\|)'
-    'beginCaptures': {
-      '3': {
-        'name': 'string.block.jsonnet'
-      },
-    },
-    'end': '^(?!$)(\\1)(\\|\\|\\|)'
-    'endCaptures': {
-      '2': {
-        'name': 'string.block.jsonnet'
-      },
-    },
+    "begin": "(?:\\|\\|\\|)(?:\\s*$)"
+    "end": "\\|\\|\\|"
+     "patterns": [
+        {
+          "begin": "^([ \t]+)(?! |\t|\\|(?=\\|))",
+          "end": "^(?!\\1|\\s*$)",
+          "name": "string.block.jsonnet"
+        }
+    ]
   },
 
   {

--- a/grammars/jsonnet.cson
+++ b/grammars/jsonnet.cson
@@ -142,15 +142,16 @@
   },
 
   {
-    "begin": "(?:\\|\\|\\|)(?:\\s*$)"
-    "end": "\\|\\|\\|"
-     "patterns": [
+      "begin": "(?:\\|\\|\\|)(?:\\s*$)",
+      "end": "^\\s*\\|\\|\\|",
+      "name": "keyword.other.jsonnet",
+      "patterns": [
         {
-          "begin": "^([ \t]+)(?! |\t|\\|(?=\\|))",
+          "begin": "^([ \t]+)(?! |\t)",
           "end": "^(?!\\1|\\s*$)",
-          "name": "string.block.jsonnet"
-        }
-    ]
+          "name": "string.unquoted.block.jsonnet"
+        },
+      ]
   },
 
   {


### PR DESCRIPTION
Back-porting update from vs-code:
- https://github.com/grafana/vscode-jsonnet/pull/28

Eventually [github](https://github.com/github-linguist/linguist/blob/fc31785655f261d1281c7e47ae2ca63d6a4aba3e/vendor/README.md?plain=1#L274) will correctly highlight these examples:

```jsonnet
{
  a: |||
 hello
|||,
  b: 0
}
```

```jsonnet
{
 a: |||
  hello
 |||
}
```


```jsonnet
{
 a:
  |||
  this is not terminated text block, but renders as if it is
  |||,
 b: true
}
```

```jsonnet
{
 a:
  |||
  this is valid example but does not work
 |||,
 b: true
}
```

![image](https://github.com/google/language-jsonnet/assets/1218946/2fdab0af-42a5-4467-b364-99a5d052101c)
